### PR TITLE
Fixed build error

### DIFF
--- a/src/svgasm.cpp
+++ b/src/svgasm.cpp
@@ -245,7 +245,7 @@ int main (int argc, char *argv[]) {
             }
 
             char tempdir[] = TEMP_DIR;
-            if (mkdtemp(tempdir) == NULL) {
+            if (mktemp(tempdir) == NULL) {
                 std::cerr << "Temporary directory creation failed." << std::endl;
                 exit(0);
             }


### PR DESCRIPTION
I got this error during the build process on my Windows 11, Intel x64 machine:
```
g++ -std=c++98 -O3 -o ./svgasm ./src/svgasm.cpp
./src/svgasm.cpp: In function 'int main(int, char**)':
./src/svgasm.cpp:248:17: error: 'mkdtemp' was not declared in this scope
             if (mkdtemp(tempdir) == NULL) {
                 ^~~~~~~
./src/svgasm.cpp:248:17: note: suggested alternative: 'mktemp'
             if (mkdtemp(tempdir) == NULL) {
                 ^~~~~~~
                 mktemp
make: *** [svgasm] Error
```
The fix was simple and I did exactly what the compiler suggested. After the change, the binary builds normally.